### PR TITLE
Update composer.json for require administrator 4.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=5.4.0",
         "illuminate/support": "4.2.*",
-        "frozennode/administrator": "dev-master"
+        "frozennode/administrator": "4.*"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
"frozennode/administrator": "dev-master" cause error because the last version require Laravel 5.

``` bash
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - yottaram/administrator-config dev-master requires frozennode/administrator dev-master -> satisfiable by frozennode/administrator[dev-master].
    - yottaram/administrator-config dev-master requires frozennode/administrator dev-master -> satisfiable by frozennode/administrator[dev-master].
    - Removal request for frozennode/administrator == 9999999-dev
    - Installation request for yottaram/administrator-config dev-master -> satisfiable by yottaram/administrator-config[dev-master].
```

Nice package @jonstavis  :+1: 
